### PR TITLE
docs: refine wording in README description

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Run core tests](https://github.com/isikerhan/setup-git/actions/workflows/run-core-tests.yml/badge.svg)](https://github.com/isikerhan/setup-git/actions/workflows/run-core-tests.yml)
 [![Run extended tests](https://github.com/isikerhan/setup-git/actions/workflows/run-extended-tests.yml/badge.svg)](https://github.com/isikerhan/setup-git/actions/workflows/run-extended-tests.yml)
 
-This action installs a specific version of Git by compiling the source code (or downloading the prebuilt version for Windows) and adds it to the `PATH`.
+This action installs a specific version of Git by building the source code (or downloading the prebuilt version for Windows) and adds it to the `PATH`.
 
 > [!WARNING]
 > [GitHub-hosted runners](https://docs.github.com/en/actions/using-github-hosted-runners)


### PR DESCRIPTION
Changed "compiling" to "building" for clearer and more accurate wording.